### PR TITLE
Update AHT10.h

### DIFF
--- a/src/AHT10.cpp
+++ b/src/AHT10.cpp
@@ -60,12 +60,14 @@ AHT10::AHT10(uint8_t address, ASAIR_I2C_SENSOR sensorName)
       - 4 other error
 */
 /**************************************************************************/
-#if defined(ESP8266)
+#if defined(ESP8266) || defined(STM32F4xx)
 bool AHT10::begin(uint8_t sda, uint8_t scl)
 {
   Wire.begin(sda, scl);
   Wire.setClock(100000);          //experimental! ESP8266 I2C bus speed: 50kHz..400kHz/50000..400000, default 100000
+  #if defined(ESP8266)
   Wire.setClockStretchLimit(230); //experimental! default 230usec
+  #endif
 #else
 bool AHT10::begin(void) 
 {

--- a/src/AHT10.h
+++ b/src/AHT10.h
@@ -95,7 +95,7 @@ class AHT10
 
    AHT10(uint8_t address = AHT10_ADDRESS_0X38, ASAIR_I2C_SENSOR = AHT10_SENSOR);
 
-   #if defined(ESP8266)
+   #if defined(ESP8266) || defined(STM32F4xx)
    bool     begin(uint8_t sda = SDA, uint8_t scl = SCL);
    #else
    bool     begin();


### PR DESCRIPTION
STM32 uses different I2C pin assignments.

The code for the ESP8266 is almost enough to fix this, but STM32 doesn't support clockstretching.

I have added additional if defined sections to add the STM32 support.